### PR TITLE
allowed players to see monster damage taken

### DIFF
--- a/src/monsters/AbstractMonster.ts
+++ b/src/monsters/AbstractMonster.ts
@@ -5,23 +5,27 @@ abstract class AbstractMonster {
   #hp: number;
   #maxHP: number;
   #ac: number;
+  #name: string;
   #location: TypeRoom;
 
   constructor({
     id,
     hp,
     ac,
+    name,
     location,
   }: {
     id: string;
     hp: number;
     ac: number;
+    name: string;
     location: TypeRoom;
   }) {
     this.#id = id;
     this.#hp = hp;
     this.#maxHP = hp;
     this.#ac = ac;
+    this.#name = name;
     this.#location = location;
   }
 
@@ -41,6 +45,10 @@ abstract class AbstractMonster {
 
   getAC(): number {
     return this.#ac;
+  }
+
+  getName(): string {
+    return this.#name;
   }
 
   takeDamage(damage: number): void {

--- a/src/monsters/ActiveMonsters.test.ts
+++ b/src/monsters/ActiveMonsters.test.ts
@@ -5,6 +5,7 @@ const mockMonster: TypeMonster = {
   getID: () => '',
   getHP: () => 69,
   getAC: () => 420,
+  getName: () => '',
   getLocationId: () => '',
   takeDamage: (damage: number) => {},
   describe: () => {},

--- a/src/monsters/generateMonsters.ts
+++ b/src/monsters/generateMonsters.ts
@@ -10,6 +10,7 @@ export default function generateMonsters() {
     id: 'grumpkin',
     hp: 15,
     ac: 13,
+    name: 'Grumpkin',
     location: startingRoom,
   });
 

--- a/src/monsters/monsterDamage.ts
+++ b/src/monsters/monsterDamage.ts
@@ -3,8 +3,9 @@ import Monster from './types/Monster';
 function monsterDamage(monster: Monster, attack: number, damage: number) {
   if (attack >= monster.getAC()) {
     monster.takeDamage(damage);
-    console.log(monster.getHP());
+    return true;
   }
+  return false;
 }
 
 export default monsterDamage;

--- a/src/monsters/types/Monster.ts
+++ b/src/monsters/types/Monster.ts
@@ -2,6 +2,7 @@ interface Monster {
   getID: () => string;
   getHP: () => number;
   getAC: () => number;
+  getName: () => string;
   getLocationId: () => string;
   takeDamage: (damage: number) => void;
   describe: () => void;

--- a/src/player/action/PlayerAction.test.ts
+++ b/src/player/action/PlayerAction.test.ts
@@ -4,6 +4,16 @@ import Weapon from '../../items/types/Weapons';
 
 jest.mock('inquirer');
 
+const mockMonster = {
+  getID: () => 'grumpkin',
+  getHP: () => 20,
+  getAC: () => 0,
+  getName: () => 'Grumpkin',
+  getLocationId: () => '',
+  takeDamage: () => {},
+  describe: () => {},
+};
+
 const mockRoom = {
   getID: () => '',
   addConnections: () => {},
@@ -41,7 +51,7 @@ const fakeInventory = {
 };
 
 describe('PlayerAction', () => {
-  test('performs an action', async () => {
+  test('performs a move', async () => {
     jest
       .spyOn(inquirer, 'prompt')
       .mockResolvedValue({ action: 'move forward' });
@@ -52,5 +62,20 @@ describe('PlayerAction', () => {
     const playerAction = new PlayerAction(location, fakeInventory);
     await playerAction.action('', []);
     expect(mockForward).toHaveBeenCalled();
+  });
+
+  test('performs an attack', async () => {
+    const mockTakeDamage = jest.fn();
+    jest
+      .spyOn(inquirer, 'prompt')
+      .mockResolvedValue({ action: 'attack grumpkin' });
+
+    const location = { ...fakeLocation };
+
+    const playerAction = new PlayerAction(location, fakeInventory);
+    await playerAction.action('', [
+      { ...mockMonster, takeDamage: mockTakeDamage },
+    ]);
+    expect(mockTakeDamage).toHaveBeenCalled();
   });
 });

--- a/src/player/action/PlayerAction.ts
+++ b/src/player/action/PlayerAction.ts
@@ -44,7 +44,7 @@ class PlayerAction {
       formatLog('Follow the instructions dumbass.');
       answer = await inquirer.prompt(input);
       commands = answer.action.split(' ');
-      validAnswer = this._validateCommand(answer.action);
+      validAnswer = this._validateCommand(commands[0]);
     }
 
     return this._doAction(commands[0], commands[1], validMonsters);
@@ -88,11 +88,25 @@ class PlayerAction {
         const targetMonster = validMonsters.find(
           (monster) => monster.getID() === attackResults.id
         );
-        monsterDamage(
+        const didHit = monsterDamage(
           targetMonster,
           attackResults.attackValue,
           attackResults.damageValue
         );
+        if (didHit) {
+          formatLog(
+            `You struck the ${targetMonster.getName()} for ${
+              attackResults.damageValue
+            } damage. |${targetMonster.getName()} HP: ${targetMonster.getHP()}| |Attack: ${
+              attackResults.attackValue
+            }|`
+          );
+        } else
+          formatLog(
+            `You missed the ${targetMonster.getName()}. |Attack: ${
+              attackResults.attackValue
+            }|`
+          );
         break;
       default:
         throw new Error('Invalid Command');


### PR DESCRIPTION
This PR is so that players can see the effects of their attack actions.

- Added ability for players to see the damage taken by monsters through playerAction. Also added getName function to the Monster class to help differentiate between current and future monsters.

- Expands the PlayerAction._doAction to give players feedback on the attack action.