### PR TITLE
shortened descriptions and put icons into a grid

### DIFF
--- a/src/components/ReadoutGrid/InfoBlocks.tsx
+++ b/src/components/ReadoutGrid/InfoBlocks.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import "styles/_containers_and_frames.scss";
 import "styles/_readout_box.scss";
+import "styles/_icon_grid.scss";
 import TerminalLogContext from "context/TerminalLog";
 import getImageForMonster from "util/getImageForMonster";
 
@@ -12,8 +13,8 @@ function InfoBlocks({ monsters }) {
       className="rpgui-container framed readout-box"
       style={{ gridColumn: 5 }}
     >
-      Monsters In Area:
-      <div>
+      <div>Monsters In Area:</div> <br />
+      <div className="icon-grid">
         {monsters.map((monster) => {
           return (
             <button

--- a/src/components/ReadoutGrid/SpellRepertoire.tsx
+++ b/src/components/ReadoutGrid/SpellRepertoire.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import "styles/_containers_and_frames.scss";
 import "styles/_readout_box.scss";
+import "styles/_icon_grid.scss";
 import TerminalLogContext from "context/TerminalLog";
 import getImageForSpell from "util/getImageForSpell";
 
@@ -12,8 +13,8 @@ function SpellRepertoire({ spells }) {
       className="rpgui-container framed readout-box"
       style={{ gridColumn: 1 }}
     >
-      Spell Repertoire:
-      <div>
+      <div>Spell Repertoire:</div> <br />
+      <div className="icon-grid">
         {spells.map((spell) => {
           return (
             <button

--- a/src/components/ReadoutGrid/Weapons.tsx
+++ b/src/components/ReadoutGrid/Weapons.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import "styles/_containers_and_frames.scss";
 import "styles/_readout_box.scss";
+import "styles/_icon_grid.scss";
 import TerminalLogContext from "context/TerminalLog";
 import getImageForItem from "util/getImageForItem";
 
@@ -12,8 +13,8 @@ function Weapons({ weapons }) {
       className="rpgui-container framed readout-box"
       style={{ gridColumn: 1 }}
     >
-      Weapons:
-      <div>
+      <div>Weapons: </div> <br />
+      <div className="icon-grid">
         {weapons.map((weapon) => {
           return (
             <button

--- a/src/monsters/creatures/Grumpkin.ts
+++ b/src/monsters/creatures/Grumpkin.ts
@@ -4,11 +4,15 @@ import formatLog from "../../util/formatLog";
 class Grumpkin extends AbstractMonster {
   describe(): string {
     return formatLog([
-      "A small, dangerously round creature with four limbs aiming to do nothing but cause you harm... to your hat specifically.",
+      "A thing of malice, its description matches -",
 
-      "A thing of malice, its description matches - skin green, greasy and warted. Head full of tusk and matted hair. Gnarled and worn.",
+      "A small, dangerously round creature with four limbs.",
+
+      "Skin green, greasy and warted. Head full of tusk and matted hair. Gnarled and worn.",
 
       "It holds a shiv made in the sewers of Draulheim.",
+
+      "It aims to do nothing but cause you harm... to your hat specifically.",
     ]);
   }
 }

--- a/src/styles/_icon_grid.scss
+++ b/src/styles/_icon_grid.scss
@@ -1,0 +1,7 @@
+.icon-grid {
+  display: grid;
+  justify-items: center;
+  grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
+  grid-auto-rows: auto;
+  row-gap: 1em;
+}

--- a/src/styles/_terminal.scss
+++ b/src/styles/_terminal.scss
@@ -14,7 +14,7 @@
   font-family: "Fira Mono", Consolas, Menlo, Monaco, "Courier New", Courier,
     monospace;
   border-radius: 4px;
-  padding: 75px 45px 35px;
+  padding: 45px 45px 45px;
   position: relative;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
@@ -22,7 +22,7 @@
 
 .react-terminal {
   height: 100%;
-  width: fit-content;
+  width: 100%;
   overflow-y: auto;
   display: flex;
   flex-direction: column;

--- a/src/tower-layout/rooms/Bedroom.ts
+++ b/src/tower-layout/rooms/Bedroom.ts
@@ -1,15 +1,15 @@
-import AbstractRoom from './AbstractRoom';
-import formatLog from '../../util/formatLog';
+import AbstractRoom from "./AbstractRoom";
+import formatLog from "../../util/formatLog";
 class Bedroom extends AbstractRoom {
   constructor() {
-    super('bedroom');
+    super("bedroom");
   }
 
   description(): string {
     return formatLog([
       `You are at the apex of your grand wizard tower.`,
       `To your immediate right is a dastardly grumpkin, angry and looking to steal your hat.`,
-      `To your left is a nightstand, your wand jammed firmly in a loaf of bread you've left overnight...slob.`,
+      `To your left is a nightstand, your wand jammed firmly in a loaf of bread you've left overnight.`,
       `In front of you is an open window across the bedroom, the morning sky beckoning you.`,
       `Centered in the middle of the room and the tower itself is a spiral staircase leading ever downward.`,
       `Behind you is a wall.`,


### PR DESCRIPTION
Shortened some descriptions to make sure text doesn't wrap in the maximum terminal size.

Unsure how many items/monsters there be for the player to have, but at least now they'll fit into grids as they are added and overflow into rows.