### PR TITLE
moved style imports / made stat menu for monsters

### DIFF
--- a/src/components/GameEngine/index.tsx
+++ b/src/components/GameEngine/index.tsx
@@ -1,6 +1,20 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import ReadoutGrid from "../ReadoutGrid";
 import "styles/_containers_and_frames.scss";
+import "styles/_scrollbars.scss";
+import "styles/_health_bar.scss";
+import "styles/_hr.scss";
+
+import "styles/_readout_box.scss";
+
+import "styles/_dropdown.scss";
+import "styles/_help_button.scss";
+import "styles/_button.scss";
+
+import "styles/_stat_grid.scss";
+import "styles/_icon_grid.scss";
+import "styles/_index_grid.scss";
+import "styles/_readout_grid.scss";
 
 import { TerminalController } from "../TerminalController";
 import TerminalLogContext from "../../context/TerminalLog";
@@ -60,7 +74,7 @@ function GameEngine({ setGameState }) {
       }}
     >
       <div
-        className="container rpgui-container framed-grey"
+        className="container rpgui-container rpgui-content framed-grey"
         style={{ height: "100vh" }}
       >
         {helpToggle ? (

--- a/src/components/ReadoutGrid/HelpMenu.tsx
+++ b/src/components/ReadoutGrid/HelpMenu.tsx
@@ -1,7 +1,3 @@
-import React from "react";
-import "styles/_containers_and_frames.scss";
-import "styles/_button.scss";
-
 function HelpMenu({ setHelpToggle }) {
   return (
     <div

--- a/src/components/ReadoutGrid/InfoBlocks.tsx
+++ b/src/components/ReadoutGrid/InfoBlocks.tsx
@@ -1,32 +1,24 @@
-import React, { useContext } from "react";
-import "styles/_containers_and_frames.scss";
-import "styles/_readout_box.scss";
-import "styles/_icon_grid.scss";
-import TerminalLogContext from "context/TerminalLog";
 import getImageForMonster from "util/getImageForMonster";
 
-function InfoBlocks({ monsters }) {
-  const terminalLog = useContext(TerminalLogContext);
-
+function InfoBlocks({ monsters, setMonsterStatReadout }) {
   return (
     <div
       className="rpgui-container framed readout-box"
       style={{ gridColumn: 5 }}
     >
-      <div>Monsters In Area:</div> <br />
-      <div className="icon-grid">
+      <div style={{ gridRow: 1 }}>Monsters In Area:</div> <br />
+      <div className="icon-grid" style={{ gridRow: 2 }}>
         {monsters.map((monster) => {
           return (
             <button
+              id={monster}
               style={{
                 backgroundImage: `url(${getImageForMonster(monster.getID())})`,
                 backgroundSize: "50px 50px",
                 height: `50px`,
                 width: "50px",
               }}
-              onClick={() => {
-                terminalLog.add("\n" + monster.describe());
-              }}
+              onClick={() => setMonsterStatReadout(monster)}
             />
           );
         })}

--- a/src/components/ReadoutGrid/MonsterStats.tsx
+++ b/src/components/ReadoutGrid/MonsterStats.tsx
@@ -1,0 +1,79 @@
+import { useContext } from "react";
+import TerminalLogContext from "context/TerminalLog";
+import "styles/_input.scss";
+
+function MonsterStats({ monsters, monsterStatReadout, setMonsterStatReadout }) {
+  const terminalLog = useContext(TerminalLogContext);
+  const monster = monsterStatReadout;
+
+  return (
+    <div
+      className="rpgui-container framed readout-box"
+      style={{ gridColumn: 5, padding: `3px` }}
+    >
+      <div
+        className="rpgui-container framed-grey"
+        style={{
+          height: "100%",
+          width: "100%",
+          overflowY: "auto",
+          padding: "6px",
+        }}
+      >
+        <div
+          className="rpgui-content"
+          style={{
+            display: "grid",
+            gridTemplateColumns: `1fr`,
+            gridTemplateRows: "1fr 0.25fr 0.5fr 0.5fr 0.5fr 0.5fr",
+            rowGap: `0.25em`,
+          }}
+        >
+          <button
+            className="rpgui-button monster-stat-button"
+            onClick={() => setMonsterStatReadout(null)}
+          >
+            Back
+          </button>
+          <hr style={{ width: `100%`, marginBottom: 0, margin: 0 }} />
+
+          <label>[{monster.getName()}]'s HP:</label>
+          <div className="health-bar">
+            <div className="health-bar-glass-before"></div>
+            <div className="health-bar-glass" style={{ textAlign: "center" }}>
+              <span
+                style={{
+                  gridColumn: 2,
+                  position: "absolute",
+                  marginLeft: "-8px",
+                }}
+              >
+                {monster.getHP()}
+              </span>
+              <div
+                className="health-bar-fluid"
+                style={{
+                  width: `${(monster.getHP() / monster.getMaxHP()) * 100}%`,
+                }}
+              ></div>
+            </div>
+            <div className="health-bar-glass-after"></div>
+          </div>
+          <hr style={{ width: `100%`, marginBottom: 0 }} />
+          <div>AC: {monster.getAC()}</div>
+          <hr style={{ width: `100%`, marginBottom: 0 }} />
+          <button
+            className="rpgui-button monster-describe-button"
+            onClick={() => {
+              terminalLog.add("\n" + monster.describe());
+            }}
+          >
+            Describe
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MonsterStats;

--- a/src/components/ReadoutGrid/PlayerStatsReadout.tsx
+++ b/src/components/ReadoutGrid/PlayerStatsReadout.tsx
@@ -1,15 +1,9 @@
-import React from "react";
-import "styles/_scrollbars.scss";
-import "styles/_containers_and_frames.scss";
-import "styles/_readout_box.scss";
-import "styles/_stat_grid.scss";
-
 function PlayerStatsReadout({ playerStats }) {
   const mobileCheck = window.innerWidth > 700;
 
   return (
     <div
-      className="rpgui-container framed rpgui-content readout-box"
+      className="rpgui-container framed readout-box"
       style={{
         gridColumn: 3,
         overflowWrap: "anywhere",

--- a/src/components/ReadoutGrid/SpellRepertoire.tsx
+++ b/src/components/ReadoutGrid/SpellRepertoire.tsx
@@ -1,7 +1,4 @@
-import React, { useContext } from "react";
-import "styles/_containers_and_frames.scss";
-import "styles/_readout_box.scss";
-import "styles/_icon_grid.scss";
+import { useContext } from "react";
 import TerminalLogContext from "context/TerminalLog";
 import getImageForSpell from "util/getImageForSpell";
 

--- a/src/components/ReadoutGrid/Weapons.tsx
+++ b/src/components/ReadoutGrid/Weapons.tsx
@@ -1,7 +1,4 @@
-import React, { useContext } from "react";
-import "styles/_containers_and_frames.scss";
-import "styles/_readout_box.scss";
-import "styles/_icon_grid.scss";
+import { useContext } from "react";
 import TerminalLogContext from "context/TerminalLog";
 import getImageForItem from "util/getImageForItem";
 

--- a/src/components/ReadoutGrid/index.tsx
+++ b/src/components/ReadoutGrid/index.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from "react";
-import "styles/_readout_grid.scss";
-import "styles/_dropdown.scss";
-import "styles/_containers_and_frames.scss";
-import "styles/_index_grid.scss";
-import "styles/_help_button.scss";
+import { useState } from "react";
 import Weapons from "./Weapons";
 import SpellRepertoire from "./SpellRepertoire";
 import InfoBlocks from "./InfoBlocks";
 import PlayerStatsReadout from "./PlayerStatsReadout";
+import MonsterStats from "./MonsterStats";
+import Monster from "monsters/types/Monster";
 
 function ReadoutGrid({
   monsters,
@@ -17,6 +14,9 @@ function ReadoutGrid({
   setHelpToggle,
 }) {
   const [readout, setReadout] = useState<string>("Weapons");
+  const [monsterStatReadout, setMonsterStatReadout] = useState<Monster | null>(
+    null
+  );
 
   const options = ["Spells", "Weapons", "Apparel", "Potions", "Misc"];
 
@@ -66,7 +66,19 @@ function ReadoutGrid({
         }
 
         <PlayerStatsReadout playerStats={playerStats} />
-        <InfoBlocks monsters={monsters} />
+
+        {monsterStatReadout ? (
+          <MonsterStats
+            monsters={monsters}
+            monsterStatReadout={monsterStatReadout}
+            setMonsterStatReadout={setMonsterStatReadout}
+          />
+        ) : (
+          <InfoBlocks
+            setMonsterStatReadout={setMonsterStatReadout}
+            monsters={monsters}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -31,7 +31,7 @@ function StartScreen({
           className="rpgui-button golden"
           style={{ gridColumn: 2, fontSize: "12px" }}
         >
-          <p style={{ paddingTop: "auto" }}>Start Game</p>
+          <p style={{ paddingTop: `5px` }}>Start Game</p>
         </button>
       </div>
     </div>

--- a/src/components/TerminalController.tsx
+++ b/src/components/TerminalController.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from "react";
 import TerminalLogContext from "../context/TerminalLog";
 import Terminal from "./Terminal";
-import "styles/_readout_box.scss";
 
 export function TerminalController({ playerAction, monsters, setGameState }) {
   const terminalLogContext = useContext(TerminalLogContext);

--- a/src/monsters/AbstractMonster.ts
+++ b/src/monsters/AbstractMonster.ts
@@ -43,6 +43,10 @@ abstract class AbstractMonster {
     return this.#hp;
   }
 
+  getMaxHP(): number {
+    return this.#maxHP;
+  }
+
   getAC(): number {
     return this.#ac;
   }

--- a/src/styles/_containers_and_frames.scss
+++ b/src/styles/_containers_and_frames.scss
@@ -9,7 +9,6 @@
   // z-index: 10;
   font-family: "VT323";
   font-size: calc(10px + (24 - 10) * ((100vw - 300px) / (2560 - 300)));
-  overflow: show;
 }
 
 /* game div with background image*/

--- a/src/styles/_health_bar.scss
+++ b/src/styles/_health_bar.scss
@@ -1,0 +1,53 @@
+.health-bar {
+  display: grid;
+  grid-template-columns: 10% 1fr 10%;
+  position: relative;
+  margin-right: 4px;
+}
+
+.health-bar-glass {
+  position: absolute;
+  grid-column: 1;
+
+  width: 100%;
+  height: 100%;
+  border: 2px solid #000000;
+  box-shadow: inset 0 0 0 2px #dbd75d;
+}
+
+.health-bar-glass-before {
+  z-index: 1;
+  grid-column: 1 /1;
+  position: absolute;
+  margin: 2px;
+  height: 100%;
+  width: 100%;
+  left: 0px;
+  background-image: url("img/progress-bar-left.png");
+  background-size: 100% 100%;
+}
+
+.health-bar-glass-after {
+  z-index: 1;
+  grid-column: 3 / 3;
+  position: absolute;
+  margin: 2px;
+  height: 100%;
+  width: 100%;
+  right: -5px;
+  background-image: url("img/progress-bar-right.png");
+  background-size: 100% 100%;
+}
+
+.health-bar-fluid {
+  width: 100%;
+  height: 100%;
+  background: #d34549;
+  box-shadow: inset 0 3px 0 -1px #d3aa9a, inset 0 -4px 0 -2px #4d494d,
+    inset 4px 0 0 -2px #4d494d, inset -4px 0 0 -2px #4d494d;
+}
+
+.anim-width {
+  -webkit-animation: anim50to100 2s infinite;
+  animation: anim50to100 2s infinite;
+}

--- a/src/styles/_help_button.scss
+++ b/src/styles/_help_button.scss
@@ -1,7 +1,26 @@
 .help-button {
   min-height: 40px;
-  min-width: 110px;
+  min-width: 80px !important;
   max-height: 40px;
-  max-width: 110px;
+  max-width: 80px !important;
   margin-top: 0px;
+  padding: 0px !important;
+}
+
+.monster-stat-button {
+  min-height: 15px;
+  min-width: 50px !important;
+  max-height: 45px;
+  max-width: 65px !important;
+  margin-top: 0px;
+  padding: 0px !important;
+}
+
+.monster-describe-button {
+  min-height: 15px;
+  min-width: 50px !important;
+  max-height: 45px;
+  max-width: 120px !important;
+  margin-top: 0px;
+  padding: 0px !important;
 }

--- a/src/styles/_readout_grid.scss
+++ b/src/styles/_readout_grid.scss
@@ -1,5 +1,5 @@
 .readout-grid {
   display: grid;
-  grid-template-columns: 7fr 1fr 7fr 1fr 7fr;
+  grid-template-columns: 7fr 0.5fr 7fr 0.5fr 7fr;
   color: white;
 }

--- a/src/styles/_terminal.scss
+++ b/src/styles/_terminal.scss
@@ -113,7 +113,8 @@
 
 .terminal-hidden-input {
   position: fixed;
-  left: -1000px;
+  z-index: -1;
+  opacity: 0;
 }
 
 /* .react-terminal-progress {


### PR DESCRIPTION
Realized the component orchestrator can give style classes through inheritance. Can import directly if inheritance is not desired.

Monster icon no longer describes monster in terminal. It instead toggles the stat menu for the icon's creature.

Toggleable monster stats function similarly to the help menu through useState, and have a functioning health bar. Descriptions can be requested to the terminal through the menu. 

Will add death state for monsters next to make use of this.